### PR TITLE
Fixing roberta annotation

### DIFF
--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -126,13 +126,19 @@ def _compute_subseq(args):
     subseq = []
     max_iters = len(offsets) + 5
     iter_count = 0
+    last_stop = None
     while start < len(offsets):
         iter_count += 1
         if iter_count > max_iters:
+            true_count = sum(token_sw)
             logger.warning(
-                "Offset splitting exceeded max iterations (doc index %s, tokens=%s).",
+                "Offset splitting exceeded max iterations (doc index %s, tokens=%s, seq_len=%s, last_start=%s, last_stop=%s, subword_tokens=%s).",
                 index,
                 len(offsets),
+                seq_len,
+                start,
+                last_stop,
+                true_count,
             )
             break
         while token_sw[start]:
@@ -153,6 +159,7 @@ def _compute_subseq(args):
             stop = min(len(offsets), start + seq_len)
 
         subseq.append(start)
+        last_stop = stop
         start = stop
     duration = time.perf_counter() - start_time
     return {"index": index, "subseq": subseq, "token_count": len(offsets), "duration_s": duration}

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -117,7 +117,9 @@ def _compute_subseq(args):
     start_time = time.perf_counter()
     token_sw = [False]
     token_sw += [
-        word_ids[i + 1] == word_ids[i]
+        (word_ids[i + 1] is not None) and
+        (word_ids[i] is not None) and
+        (word_ids[i + 1] == word_ids[i])
         for i in range(len(word_ids) - 1)
     ]
     start = 0
@@ -141,14 +143,14 @@ def _compute_subseq(args):
         stop = start + seq_len
         if stop < len(offsets):
             while token_sw[stop]:
-                if stop == 0:
+                if stop <= start:
                     break
                 stop -= 1
         else:
             stop = len(offsets)
 
         if stop <= start:
-            stop = min(len(offsets), start + 1)
+            stop = min(len(offsets), start + seq_len)
 
         subseq.append(start)
         start = stop


### PR DESCRIPTION
This was broken, in multiple ways.

### Issue 1: Split sequences pegged CPU / ran for minutes

**Root cause:** subword‑split guard used word_ids, but in this path word_ids were all None or a single repeated value, causing the algorithm to treat nearly every token as a subword continuation. This collapsed split boundaries to 1‑token increments and led to thousands of segments and long CPU runs.

**Resolution:** detect unusable word_ids and disable subword‑avoidance for that doc. Also added loop‑progress guards to prevent stagnation.

### Issue 2: Timeout fallback allowed oversize sequences

**Root cause:** when split offset calculation timed out, the code fell back to [0], which meant “don’t split” and allowed sequences >512 tokens into the model.

**Resolution:** removed the timeout and parallelized offset calculation with a configurable process pool. This prioritizes correctness over performance.

### Issue 3: Tokenizer missing from model repo

**Root cause:** KindLab/roberta-deid doesn’t include tokenizer files, so AutoTokenizer.from_pretrained(modelDir) produced a broken tokenizer (empty encodings, absurd max length, index errors).

**Resolution:** validate tokenizer usability; if missing/invalid, fall back to roberta-base tokenizer. Added logging to show which tokenizer is actually used.

### Issue 4: No annotations despite model running

**Root cause:** combination of broken tokenizer (empty encodings) and unusable word_ids meant label extraction produced none, even though inference ran.

**Resolution:** tokenizer fallback fixed encodings; added label extraction fallback that operates on token offsets when word_ids aren’t reliable.

### logging cleanup

Added diagnostics for tokenization/splitting/model labels; moved to DEBUG and added LOG_LEVEL env var.